### PR TITLE
Merge Decoder's onImageScanline into one single function

### DIFF
--- a/decoder.cpp
+++ b/decoder.cpp
@@ -458,14 +458,13 @@ bool Decoder::readGlobalMaskInfo(LayersInformation& layers)
   const uint16_t maskOpacity = read16();
   const uint8_t  maskKind = read8();
 
-  if (maskOpacity != 0 && maskOpacity != 100)
+  if (maskOpacity > 100)
     throw std::runtime_error("Unexpected opacity for mask");
 
   if (maskKind != 0 && maskOpacity != 1 && maskKind != 128)
     throw std::runtime_error("Unexpected mask kind");
 
-  layers.maskInfo.opacity =
-    static_cast<GlobalMaskInfo::Opacity>(maskOpacity);
+  layers.maskInfo.opacity = maskOpacity;
   layers.maskInfo.kind =
     static_cast<GlobalMaskInfo::MaskKind>(maskKind);
 
@@ -597,8 +596,8 @@ bool Decoder::readImage(const ImageData& img)
       case CompressionMethod::RawImageData:
         for (int y=0; y<img.height; ++y) {
 
-          std::vector<uint32_t> rawData;
-          rawData.reserve(img.width);
+          std::vector<uint8_t> rawData;
+          rawData.reserve(img.width * (img.depth == 1 ? 1: img.depth/8));
 
           for (int x=0; x<img.width; ) {
             if (img.depth == 1) {
@@ -626,12 +625,16 @@ bool Decoder::readImage(const ImageData& img)
               uint16_t word = read16();
               TRACE(" %04x", word);
               ++x;
-              rawData.push_back(word);
+              rawData.push_back(word & 0xff);
+              rawData.push_back(word >> 8);
             }
             else if (img.depth == 32) {
               uint32_t dword = read32();
               TRACE(" %08x", dword);
               ++x;
+              rawData.push_back(dword >> 24);
+              rawData.push_back(dword >> 16);
+              rawData.push_back(dword >> 8);
               rawData.push_back(dword);
             }
             else {
@@ -642,7 +645,9 @@ bool Decoder::readImage(const ImageData& img)
           TRACE("\n");
 
           if (m_delegate)
-            m_delegate->onImageScanline(img, y, chanID, rawData);
+            m_delegate->onImageScanline(
+              img, y, chanID,
+              &rawData[0], rawData.size());
         }
         break;
 

--- a/psd.h
+++ b/psd.h
@@ -422,18 +422,13 @@ namespace psd {
   };
 
   struct GlobalMaskInfo {
-    enum class Opacity: uint16_t {
-      Transparent = 0,
-      Opaque = 100
-    };
-
     enum class MaskKind: uint8_t {
       Inverted = 0,
       ColorProtected = 1,
       ExactPixelValue = 128,
     };
 
-    Opacity  opacity;
+    uint16_t opacity;
     MaskKind kind;
   };
 
@@ -517,11 +512,6 @@ namespace psd {
                                  const ChannelID chanID,
                                  const uint8_t* data,
                                  const int bytes) { }
-    // Emitted for RAW images
-    virtual void onImageScanline(const ImageData& imgData,
-                                 const int y,
-                                 const ChannelID chanID,
-                                 const std::vector<uint32_t>& data) { }
     virtual void onEndImage(const ImageData& img) { }
   };
 


### PR DESCRIPTION
Parts of the suggestions made in the [PR for aseprite](https://github.com/aseprite/aseprite/pull/3000) says to merge the two `DecoderDelegate::onImageScanline(...)` into a single function regardless of the image's depth. Calling delegate code has enough information to extract the necessary information from the data sent.