### PR TITLE
Provide improvements to the interface

### DIFF
--- a/decoder.cpp
+++ b/decoder.cpp
@@ -196,13 +196,7 @@ bool Decoder::readSectionDivider(LayerRecord& layerRecord,
   // 4 possible values => 0 = any other type of layer,
   // 1 = open "folder", 2 = closed "folder",
   // 3 = bounding section divider, hidden in the UI
-  const uint32_t sectionType = read32();
-  if(sectionType > 3)
-    throw std::runtime_error("unexpected section divider encountered");
-  if (sectionType == 1)
-    layerRecord.layerType = LayerType::LayerGroupEnd;
-  else if (sectionType == 3)
-    layerRecord.layerType = LayerType::LayerGroupStart;
+  layerRecord.sectionType = SectionType(read32());
 
   if (length < 12)
     return true;
@@ -470,7 +464,7 @@ bool Decoder::readLayerRecord(LayersInformation& layers,
   uint32_t bm = read32();
   layerRecord.blendMode = LayerBlendMode(bm);
   layerRecord.opacity = read8();
-  layerRecord.layerType = LayerType::LayerImage;
+  layerRecord.sectionType = SectionType::Others;
 
   TRACE(" blendMode=%d %d %d %d\n",
          ((bm >> 24) & 255),

--- a/image_resources.cpp
+++ b/image_resources.cpp
@@ -115,6 +115,15 @@ const char* ImageResource::resIDString(uint16_t resID)
   return "";
 }
 
+std::string key_to_string(const uint32_t key)
+{
+  std::string str(4, '0');
+  for (int i=0; i<4; ++i) {
+    str[3-i] = char(key>>(8*i));
+  }
+  return str;
+}
+
 // static
 bool ImageResource::resIDHasDescriptor(uint16_t resID)
 {
@@ -194,7 +203,8 @@ OSTypeClassMetaType Decoder::parseDescrVariable()
   const uint32_t classIDLength = read32();
   OSTypeClassMetaType meta;
   if (classIDLength == 0) {
-    meta.name = std::to_string(read32());
+    const uint32_t key = read32();
+    meta.name = key_to_string(key);
   }
   else {
     meta.name.resize(classIDLength);

--- a/image_resources.cpp
+++ b/image_resources.cpp
@@ -213,7 +213,7 @@ OSTypeClassMetaType Decoder::parseDescrVariable()
   return meta;
 }
 
-std::unique_ptr<OSType> Decoder::parseReferenceType()
+std::unique_ptr<OSTypeReference> Decoder::parseReferenceType()
 {
   const uint32_t nItems = read32();
   std::unique_ptr<OSTypeReference> ref(new OSTypeReference);
@@ -263,7 +263,7 @@ std::unique_ptr<OSType> Decoder::parseReferenceType()
   return ref;
 }
 
-std::unique_ptr<OSType> Decoder::parseListType()
+std::unique_ptr<OSTypeList> Decoder::parseListType()
 {
   const uint32_t nLength = read32();
   std::unique_ptr<OSTypeList> list(new OSTypeList);
@@ -273,7 +273,7 @@ std::unique_ptr<OSType> Decoder::parseListType()
   return list;
 }
 
-std::unique_ptr<OSType> Decoder::parseClassType()
+std::unique_ptr<OSTypeClass> Decoder::parseClassType()
 {
   std::unique_ptr<OSTypeClass> klass(new OSTypeClass);
   klass->className = getUnicodeString();
@@ -281,7 +281,7 @@ std::unique_ptr<OSType> Decoder::parseClassType()
   return klass;
 }
 
-std::unique_ptr<OSType> Decoder::parseEnumeratedType()
+std::unique_ptr<OSTypeEnum> Decoder::parseEnumeratedType()
 {
   std::unique_ptr<OSTypeEnum> e(new OSTypeEnum);
   e->typeID = parseDescrVariable();
@@ -289,11 +289,11 @@ std::unique_ptr<OSType> Decoder::parseEnumeratedType()
   return e;
 }
 
-std::unique_ptr<OSType> Decoder::parseAliasType()
+std::unique_ptr<OSTypeAlias> Decoder::parseAliasType()
 {
   const uint32_t length = read32();
   m_file->seek(m_file->tell() + length);
-  return std::unique_ptr<OSType>(new OSTypeAlias);
+  return std::unique_ptr<OSTypeAlias>(new OSTypeAlias);
 }
 
 std::unique_ptr<OSType> Decoder::parseOsTypeVariable()
@@ -359,7 +359,7 @@ std::unique_ptr<OSType> Decoder::parseOsTypeVariable()
   return value;
 }
 
-std::unique_ptr<OSType> Decoder::parseDescriptor()
+std::unique_ptr<OSTypeDescriptor> Decoder::parseDescriptor()
 {
   std::unique_ptr<OSTypeDescriptor> desc(new OSTypeDescriptor);
   desc->descriptorName = getUnicodeString();

--- a/psd.h
+++ b/psd.h
@@ -541,12 +541,12 @@ namespace psd {
     bool readSectionDivider(LayerRecord& layerRecord, const uint64_t length);
     uint64_t readAdditionalLayerInfo(LayerRecord& layerRecord);
     std::unique_ptr<OSType> parseOsTypeVariable();
-    std::unique_ptr<OSType> parseReferenceType();
-    std::unique_ptr<OSType> parseDescriptor();
-    std::unique_ptr<OSType> parseListType();
-    std::unique_ptr<OSType> parseClassType();
-    std::unique_ptr<OSType> parseEnumeratedType();
-    std::unique_ptr<OSType> parseAliasType();
+    std::unique_ptr<OSTypeReference> parseReferenceType();
+    std::unique_ptr<OSTypeDescriptor> parseDescriptor();
+    std::unique_ptr<OSTypeList> parseListType();
+    std::unique_ptr<OSTypeClass> parseClassType();
+    std::unique_ptr<OSTypeEnum> parseEnumeratedType();
+    std::unique_ptr<OSTypeAlias> parseAliasType();
     OSTypeClassMetaType parseDescrVariable();
 
     std::wstring getUnicodeString();

--- a/psd.h
+++ b/psd.h
@@ -227,10 +227,11 @@ namespace psd {
     RealUserSuppliedMask = -3,
   };
 
-  enum class LayerType: uint32_t {
-    LayerImage,
-    LayerGroupStart,
-    LayerGroupEnd
+  enum class SectionType: uint32_t {
+    Others,
+    OpenFolder,
+    CloseFolder,
+    BoundingSection,
   };
 
   struct Channel {
@@ -410,7 +411,7 @@ namespace psd {
     int32_t top, left, bottom, right;
     std::vector<Channel> channels;
     LayerBlendMode blendMode;
-    LayerType layerType;
+    SectionType sectionType;
     uint8_t opacity;
     uint8_t clipping;
     uint8_t flags;
@@ -418,6 +419,8 @@ namespace psd {
 
     bool isTransparencyProtected() const { return flags & 1; }
     bool isVisible() const { return (flags & 2) == 0; }
+    bool isOpenGroup() const { return sectionType == SectionType::BoundingSection; }
+    bool isCloseGroup() const { return sectionType == SectionType::OpenFolder; }
     int width() const { return right - left; }
     int height() const { return bottom - top; }
   };


### PR DESCRIPTION
This PR has three commits and they're meant to provide improvements to the interface exposed to client. For example, the `Preserve section type` commit removes the check on the divider section's type, `Change resource ID to string` converts all integer keys to their equivalent strings so they're more readable to the user and the third commit returns the proper type from the descriptor helper functions rather than the vague base class.