### PR TITLE
Implement the frame-by-frame animation

### DIFF
--- a/image_resources.cpp
+++ b/image_resources.cpp
@@ -366,9 +366,10 @@ std::unique_ptr<OSTypeDescriptor> Decoder::parseDescriptor()
   desc->classId = parseDescrVariable();
 
   const uint32_t nDescriptors = read32();
+  auto& descriptor = desc->descriptor.items();
   for (int i = 0; i < nDescriptors; ++i) {
     const OSTypeClassMetaType key = parseDescrVariable();
-    desc->descriptors.emplace(key.name, parseOsTypeVariable());
+    descriptor.emplace(key.name, parseOsTypeVariable());
   }
 
   return desc;


### PR DESCRIPTION
According to this [comment](https://github.com/aseprite/psd/issues/7#issuecomment-954929938), there are a couple of animation modes in Photoshop, one of which is frame-by-frame animation. In this mode, there are individual frames with some defined properties like the frame rate. In each frame, references to the layers are made, which determines which layer is enabled or disabled. 

This PR parses a PSD file with frame-by-frame animation and records the information in the `LayerRecord`.