### PR TITLE
Read  64-bit floating point values

### DIFF
--- a/image_resources.cpp
+++ b/image_resources.cpp
@@ -318,11 +318,11 @@ std::unique_ptr<OSType> Decoder::parseOsTypeVariable()
       value = parseListType();
       break;
     case OSTypeKey::Double:
-      value.reset(new OSTypeDouble(read64()));
+      value.reset(new OSTypeDouble(readDouble()));
       break;
     case OSTypeKey::UnitFloat: {
       const uint32_t unit = read32();
-      const double v = read64();
+      const double v = readDouble();
       if (!is_valid_unit_float(unit))
         throw std::runtime_error(
           "invalid unit float in descriptor type");

--- a/psd.h
+++ b/psd.h
@@ -647,6 +647,7 @@ namespace psd {
     uint64_t read64();
     uint32_t read16or32Length();
     uint64_t read32or64Length();
+    double readDouble();
     std::string readPascalString(const int alignment);
 
     DecoderDelegate* m_delegate;


### PR DESCRIPTION
One of the three most used data type in most PSD files I've encountered is the `double` and prior this PR, the lib reads a `double` as a `uint64_t` and casts it. This **almost always** result in incorrect values that makes it unusable. This PR _attempts_ to correctly read 64-bit floating point values, with a caveat that it needs to be tested on some platforms to ensure its correctness.